### PR TITLE
[CI/CD] Linux action for Xenon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,10 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install -y ninja-build clang lld cmake ccache
+        sudo apt install -y ninja-build clang lld cmake ccache \
+                           libx11-dev libxext-dev libxrandr-dev libxcursor-dev \
+                           libxi-dev libxinerama-dev libwayland-dev libxkbcommon-dev \
+                           wayland-protocols
 
     - name: Cache CMake Configuration
       uses: actions/cache@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,47 @@ jobs:
       with:
         name: Xenon-win64
         path: ${{github.workspace}}/build/Xenon.exe
+
+
+  Linux:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@main
+      with:
+        submodules: recursive
+
+    - name: Install Dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y ninja-build clang lld cmake ccache
+
+    - name: Cache CMake Configuration
+      uses: actions/cache@main
+      env:
+          cache-name: ${{ runner.os }}-xenon-cache-config
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+    - name: Cache CMake Build
+      uses: hendrikmuhs/ccache-action@v1.2.17
+      env:
+          cache-name: ${{ runner.os }}-xenon-cache-build
+      with:
+        append-timestamp: false
+        key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
+    - name: Configure CMake
+      run: cmake --fresh -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)
+
+    - name: Upload Linux Artifact
+      uses: actions/upload-artifact@main
+      with:
+        name: Xenon-linux64
+        path: ${{github.workspace}}/build/Xenon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.17
       env:
-          cache-name: ${{ runner.os }}-xenon-cache-build
+          cache-name: ${{ runner.os }}-xenon-cache-build-windows
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -85,7 +85,7 @@ jobs:
     - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.17
       env:
-          cache-name: ${{ runner.os }}-xenon-cache-build
+          cache-name: ${{ runner.os }}-xenon-cache-build-linux
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}

--- a/Xenon/Base/Config.h
+++ b/Xenon/Base/Config.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <filesystem>
 
 #include "Types.h"
@@ -34,10 +35,18 @@ inline s32 internalHeight = 720;
 // inline s32 gpuId = -1; // Vulkan physical device index. Set to negative for auto select
 
 // Filepaths.
+#ifdef __WIN32__
 inline std::string fusesTxtPath = "C:/Xbox/fuses.txt";
 inline std::string oneBlBinPath = "C:/Xbox/1bl.bin";
 inline std::string nandBinPath = "C:/Xbox/nand.bin";
 inline std::string oddDiscImagePath = "C:/Xbox/xenon.iso";
+#elif defined __linux__
+inline std::string home = getenv("HOME") ? getenv("HOME") : "";
+inline std::string fusesTxtPath = home + "/Xbox/fuses.txt";
+inline std::string oneBlBinPath = home + "/Xbox/1bl.bin";
+inline std::string nandBinPath = home + "/Xbox/nand.bin";
+inline std::string oddDiscImagePath = home + "/Xbox/xenon.iso";
+#endif
 
 // Highly experimental.
 inline int ticksPerInstruction = 1;

--- a/Xenon/Base/Config.h
+++ b/Xenon/Base/Config.h
@@ -35,7 +35,7 @@ inline s32 internalHeight = 720;
 // inline s32 gpuId = -1; // Vulkan physical device index. Set to negative for auto select
 
 // Filepaths.
-#ifdef __WIN32__
+#ifdef __WIN32
 inline std::string fusesTxtPath = "C:/Xbox/fuses.txt";
 inline std::string oneBlBinPath = "C:/Xbox/1bl.bin";
 inline std::string nandBinPath = "C:/Xbox/nand.bin";

--- a/Xenon/Base/Config.h
+++ b/Xenon/Base/Config.h
@@ -35,7 +35,7 @@ inline s32 internalHeight = 720;
 // inline s32 gpuId = -1; // Vulkan physical device index. Set to negative for auto select
 
 // Filepaths.
-#ifdef __WIN32
+#ifdef _WIN32
 inline std::string fusesTxtPath = "C:/Xbox/fuses.txt";
 inline std::string oneBlBinPath = "C:/Xbox/1bl.bin";
 inline std::string nandBinPath = "C:/Xbox/nand.bin";


### PR DESCRIPTION
- Integrates pipeline build with cmake, make, ninja and cmake cache.
- Implements proper paths for linux, resolves home path through `getenv()`

Fixes #40 
