### PR TITLE
[Xenon/IIC.cpp] Restore std::byteswap

### DIFF
--- a/Xenon/Core/XCPU/IIC/IIC.cpp
+++ b/Xenon/Core/XCPU/IIC/IIC.cpp
@@ -26,15 +26,15 @@ void Xe::XCPU::IIC::XenonIIC::writeInterrupt(u64 intAddress, u64 intData) {
   switch (ppeIntCtrlBlckReg) {
   case Xe::XCPU::IIC::CPU_WHOAMI:
     iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].REG_CPU_WHOAMI =
-      static_cast<u32>(_byteswap_uint64(intData));
+      static_cast<u32>(std::byteswap<u64>(intData));
     break;
   case Xe::XCPU::IIC::CPU_CURRENT_TSK_PRI:
     iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].REG_CPU_CURRENT_TSK_PRI =
-      static_cast<u32>(_byteswap_uint64(intData));
+      static_cast<u32>(std::byteswap<u64>(intData));
     break;
   case Xe::XCPU::IIC::CPU_IPI_DISPATCH_0:
     iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].REG_CPU_IPI_DISPATCH_0 =
-      static_cast<u32>(_byteswap_uint64(intData));
+      static_cast<u32>(std::byteswap<u64>(intData));
     genInterrupt(intType, cpusToInterrupt);
     break;
   case Xe::XCPU::IIC::INT_0x30:
@@ -75,11 +75,11 @@ void Xe::XCPU::IIC::XenonIIC::writeInterrupt(u64 intAddress, u64 intData) {
 
     // Set new Interrupt priority.
     iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].REG_CPU_CURRENT_TSK_PRI =
-      static_cast<u32>(_byteswap_uint64(intData));
+      static_cast<u32>(std::byteswap<u64>(intData));
     break;
   case Xe::XCPU::IIC::INT_MCACK:
     iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].REG_INT_MCACK =
-      static_cast<u32>(_byteswap_uint64(intData));
+      static_cast<u32>(std::byteswap<u64>(intData));
     break;
   default:
     LOG_ERROR(Xenon_IIC, "Unknown CPU Interrupt Ctrl Blck Reg being written: {:#x}", ppeIntCtrlBlckReg);
@@ -95,7 +95,7 @@ void Xe::XCPU::IIC::XenonIIC::readInterrupt(u64 intAddress, u64* intData) {
   u8 ppeIntCtrlBlckReg = intAddress & 0xFF;
   switch (ppeIntCtrlBlckReg) {
   case Xe::XCPU::IIC::CPU_CURRENT_TSK_PRI:
-    *intData = _byteswap_uint64(
+    *intData = std::byteswap<u64>(
       (u64)iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].REG_CPU_CURRENT_TSK_PRI);
     break;
   case Xe::XCPU::IIC::ACK:
@@ -123,11 +123,11 @@ void Xe::XCPU::IIC::XenonIIC::readInterrupt(u64 intAddress, u64* intData) {
       // Set the top priority interrypt to signaled
       iicState.ppeIntCtrlBlck[ppeIntCtrlBlckID].interrupts[highestPrioPos].ack = true;
 
-      *intData = _byteswap_uint64(highestPrio);
+      *intData = std::byteswap<u64>(highestPrio);
     }
     else {
       // If the queue is empty, return PRIO_NONE.
-      *intData = _byteswap_uint64(PRIO_NONE);
+      *intData = std::byteswap<u64>(PRIO_NONE);
     }
     break;
   default:


### PR DESCRIPTION
Restores C++ 23 byteswap instead of using windows byteswap, needed for big-endian (PPC) to little-endian (x86_64) 

Fixes linux building.