### PR TITLE
Fix ARM macOS Build

### DIFF
--- a/Xenon/Base/Thread.cpp
+++ b/Xenon/Base/Thread.cpp
@@ -159,7 +159,7 @@ void SetThreadName(void *thread, const std::string_view &name) {
 void SetCurrentThreadName(const std::string_view &name) {
   const char* nchar = name.data();
 #ifdef __APPLE__
-  pthread_setname_np(name);
+  pthread_setname_np(nchar);
 #elif defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
   pthread_set_name_np(pthread_self(), nchar);
 #elif defined(__NetBSD__)

--- a/Xenon/Core/XCPU/Interpreter/PPCInternal.h
+++ b/Xenon/Core/XCPU/Interpreter/PPCInternal.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#if defined(__x86_64__)
 #include <immintrin.h>
+#endif
 
 #include "Base/Types.h"
 


### PR DESCRIPTION
Fixes a typo in macOS pthread impl, and avoids including x86 intrinsics on non-x86 systems.  