### PR TITLE
[PPC_FPU] Implement `fmsub`, `fmsubs`, `fnmadd`, `fnmadds` and `fmsub`

### DIFF
--- a/Xenon/Core/XCPU/Interpreter/PPCOpcodes.h
+++ b/Xenon/Core/XCPU/Interpreter/PPCOpcodes.h
@@ -23,11 +23,6 @@ D_STUBRC(mtfsb0)
 D_STUBRC(mtfsfi)
 D_STUBRC(fctid)
 D_STUBRC(fctiw)
-D_STUBRC(fmsubs)
-D_STUBRC(fnmsub)
-D_STUBRC(fnmadd)
-D_STUBRC(fnmadds)
-D_STUBRC(fmsub)
 D_STUBRC(fsel)
 D_STUBRC(fres)
 D_STUBRC(fnabs)
@@ -394,7 +389,12 @@ extern void PPCInterpreter_fmaddsx(PPU_STATE *ppuState);
 extern void PPCInterpreter_fmulx(PPU_STATE *ppuState);
 extern void PPCInterpreter_fmulsx(PPU_STATE *ppuState);
 extern void PPCInterpreter_fmrx(PPU_STATE *ppuState);
+extern void PPCInterpreter_fmsubx(PPU_STATE *ppuState);
+extern void PPCInterpreter_fmsubsx(PPU_STATE *ppuState);
+extern void PPCInterpreter_fnmaddx(PPU_STATE *ppuState);
+extern void PPCInterpreter_fnmaddsx(PPU_STATE *ppuState);
 extern void PPCInterpreter_fnegx(PPU_STATE *ppuState);
+extern void PPCInterpreter_fnmsubx(PPU_STATE *ppuState);
 extern void PPCInterpreter_fnmsubsx(PPU_STATE *ppuState);
 extern void PPCInterpreter_frspx(PPU_STATE *ppuState);
 extern void PPCInterpreter_fsubx(PPU_STATE *ppuState);

--- a/Xenon/Core/XCPU/Interpreter/PPC_FPU.cpp
+++ b/Xenon/Core/XCPU/Interpreter/PPC_FPU.cpp
@@ -260,6 +260,58 @@ void PPCInterpreter::PPCInterpreter_fmrx(PPU_STATE *ppuState) {
   }
 }
 
+// Floating Multiply-Subtract Single
+void PPCInterpreter::PPCInterpreter_fmsubx(PPU_STATE *ppuState) {
+  /*
+  frD <- ([frA * frC] - frB)
+  */
+
+  CHECK_FPU;
+
+  FPRi(frd).valueAsDouble = (FPRi(fra).valueAsDouble * FPRi(frc).valueAsDouble) - FPRi(frb).valueAsDouble;
+
+  ppuUpdateFPSCR(ppuState, FPRi(frd).valueAsDouble, 0.0, _instr.rc);
+}
+
+// Floating Multiply-Subtract Single
+void PPCInterpreter::PPCInterpreter_fmsubsx(PPU_STATE *ppuState) {
+  /*
+  frD <- ([frA * frC] - frB)
+  */
+
+  CHECK_FPU;
+
+  FPRi(frd).valueAsDouble = static_cast<f32>((FPRi(fra).valueAsDouble * FPRi(frc).valueAsDouble) - FPRi(frb).valueAsDouble);
+
+  ppuUpdateFPSCR(ppuState, FPRi(frd).valueAsDouble, 0.0, _instr.rc);
+}
+
+// Floating Negative Multiply-Add Single
+void PPCInterpreter::PPCInterpreter_fnmaddx(PPU_STATE *ppuState) {
+  /*
+  frD <- - ([frA * frC] + frB)
+  */
+
+  CHECK_FPU;
+
+  FPRi(frd).valueAsDouble = -((FPRi(fra).valueAsDouble * FPRi(frc).valueAsDouble) + FPRi(frb).valueAsDouble);
+
+  ppuUpdateFPSCR(ppuState, FPRi(frd).valueAsDouble, 0.0, _instr.rc);
+}
+
+// Floating Negative Multiply-Add Single
+void PPCInterpreter::PPCInterpreter_fnmaddsx(PPU_STATE *ppuState) {
+  /*
+  frD <- - ([frA * frC] + frB)
+  */
+
+  CHECK_FPU;
+
+  FPRi(frd).valueAsDouble = static_cast<f32>(-((FPRi(fra).valueAsDouble * FPRi(frc).valueAsDouble) + FPRi(frb).valueAsDouble));
+
+  ppuUpdateFPSCR(ppuState, FPRi(frd).valueAsDouble, 0.0, _instr.rc);
+}
+
 // Floating Negate (x'FC00 0050')
 void PPCInterpreter::PPCInterpreter_fnegx(PPU_STATE *ppuState) {
   /*
@@ -273,6 +325,19 @@ void PPCInterpreter::PPCInterpreter_fnegx(PPU_STATE *ppuState) {
   if (_instr.rc) {
     ppuSetCR(ppuState, 1, curThread.FPSCR.FG, curThread.FPSCR.FL, curThread.FPSCR.FE, curThread.FPSCR.FU);
   }
+}
+
+// Floating Negative Multiply-Subtract Single
+void PPCInterpreter::PPCInterpreter_fnmsubx(PPU_STATE *ppuState) {
+  /*
+  frD <- - ([frA * frC] - frB)
+  */
+
+  CHECK_FPU;
+
+  FPRi(frd).valueAsDouble = -((FPRi(fra).valueAsDouble * FPRi(frc).valueAsDouble) - FPRi(frb).valueAsDouble);
+
+  ppuUpdateFPSCR(ppuState, FPRi(frd).valueAsDouble, 0.0, _instr.rc);
 }
 
 // Floating Negative Multiply-Subtract Single (x'EC00 003C')


### PR DESCRIPTION
Implementation of `fmsub`, `fmsubs`, `fnmadd`, `fnmadds` and `fmsub` according to IBM documentation.