### PR TITLE
Empty Dummy Renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,17 @@ if (GFX_ENABLED)
     Xenon/Render/OpenGL/OGLShader.h
     Xenon/Render/OGLRenderer.h
     Xenon/Render/OGLRenderer.cpp
+    Xenon/Render/GUI/Dummy.cpp
+    Xenon/Render/GUI/Dummy.h
+    Xenon/Render/Dummy/Factory/DummyResourceFactory.h
+    Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
+    Xenon/Render/Dummy/Factory/DummyShaderFactory.h
+    Xenon/Render/Dummy/DummyTexture.cpp
+    Xenon/Render/Dummy/DummyTexture.h
+    Xenon/Render/Dummy/DummyBuffer.cpp
+    Xenon/Render/Dummy/DummyBuffer.h
+    Xenon/Render/DummyRenderer.h
+    Xenon/Render/DummyRenderer.cpp
   )
 endif()
 set(microprofile_dir Deps/ThirdParty/microprofile)

--- a/Xenon/Render/Dummy/DummyBuffer.cpp
+++ b/Xenon/Render/Dummy/DummyBuffer.cpp
@@ -1,0 +1,13 @@
+// Copyright 2025 Xenon Emulator Project
+
+#include "DummyBuffer.h"
+
+void Render::DummyBuffer::CreateBuffer(u32 size, const void *data, eBufferUsage usage, eBufferType type) {}
+
+void Render::DummyBuffer::UpdateBuffer(u32 offset, u32 size, const void *data) {}
+
+void Render::DummyBuffer::Bind() {}
+
+void Render::DummyBuffer::Unbind() {}
+
+void Render::DummyBuffer::DestroyBuffer() {}

--- a/Xenon/Render/Dummy/DummyBuffer.cpp
+++ b/Xenon/Render/Dummy/DummyBuffer.cpp
@@ -2,12 +2,22 @@
 
 #include "DummyBuffer.h"
 
-void Render::DummyBuffer::CreateBuffer(u32 size, const void *data, eBufferUsage usage, eBufferType type) {}
+void Render::DummyBuffer::CreateBuffer(u32 size, const void *data, eBufferUsage usage, eBufferType type) {
+  LOG_INFO(Render, "DummyBuffer::CreateBuffer: {}, {}, {}", size, static_cast<u8>(usage), static_cast<u8>(size));
+}
 
-void Render::DummyBuffer::UpdateBuffer(u32 offset, u32 size, const void *data) {}
+void Render::DummyBuffer::UpdateBuffer(u32 offset, u32 size, const void *data) {
+  LOG_INFO(Render, "DummyBuffer::UpdateBuffer: {}, {}", offset, size);
+}
 
-void Render::DummyBuffer::Bind() {}
+void Render::DummyBuffer::Bind() {
+  LOG_INFO(Render, "DummyBuffer::Bind");
+}
 
-void Render::DummyBuffer::Unbind() {}
+void Render::DummyBuffer::Unbind() {
+  LOG_INFO(Render, "DummyBuffer::Unbind");
+}
 
-void Render::DummyBuffer::DestroyBuffer() {}
+void Render::DummyBuffer::DestroyBuffer() {
+  LOG_INFO(Render, "DummyBuffer::DestroyBuffer");
+}

--- a/Xenon/Render/Dummy/DummyBuffer.h
+++ b/Xenon/Render/Dummy/DummyBuffer.h
@@ -1,0 +1,24 @@
+// Copyright 2025 Xenon Emulator Project
+
+#pragma once
+
+#include "Base/Types.h"
+#include "Render/Abstractions/Buffer.h"
+
+namespace Render {
+
+class DummyBuffer : public Buffer {
+public:
+    DummyBuffer() = default;
+    ~DummyBuffer() {
+        DestroyBuffer();
+    }
+
+    void CreateBuffer(u32 size, const void *data, eBufferUsage usage, eBufferType type) override;
+    void UpdateBuffer(u32 offset, u32 size, const void *data) override;
+    void Bind() override;
+    void Unbind() override;
+    void DestroyBuffer() override;
+};
+
+} // namespace Render

--- a/Xenon/Render/Dummy/DummyBuffer.h
+++ b/Xenon/Render/Dummy/DummyBuffer.h
@@ -9,16 +9,16 @@ namespace Render {
 
 class DummyBuffer : public Buffer {
 public:
-    DummyBuffer() = default;
-    ~DummyBuffer() {
-        DestroyBuffer();
-    }
+  DummyBuffer() = default;
+  ~DummyBuffer() {
+    DestroyBuffer();
+  }
 
-    void CreateBuffer(u32 size, const void *data, eBufferUsage usage, eBufferType type) override;
-    void UpdateBuffer(u32 offset, u32 size, const void *data) override;
-    void Bind() override;
-    void Unbind() override;
-    void DestroyBuffer() override;
+  void CreateBuffer(u32 size, const void *data, eBufferUsage usage, eBufferType type) override;
+  void UpdateBuffer(u32 offset, u32 size, const void *data) override;
+  void Bind() override;
+  void Unbind() override;
+  void DestroyBuffer() override;
 };
 
 } // namespace Render

--- a/Xenon/Render/Dummy/DummyBuffer.h
+++ b/Xenon/Render/Dummy/DummyBuffer.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
-#include "Base/Types.h"
 #include "Render/Abstractions/Buffer.h"
+
+#include "Base/Types.h"
+#include "Base/Logging/Log.h"
 
 namespace Render {
 

--- a/Xenon/Render/Dummy/DummyTexture.cpp
+++ b/Xenon/Render/Dummy/DummyTexture.cpp
@@ -1,0 +1,19 @@
+// Copyright 2025 Xenon Emulator Project
+
+#include "DummyTexture.h"
+
+void Render::DummyTexture::CreateTextureHandle(u32 width, u32 height, s32 flags) {}
+
+void Render::DummyTexture::CreateTextureWithData(u32 width, u32 height, eDataFormat format, u8* data, u32 dataSize, s32 flags) {}
+
+void Render::DummyTexture::ResizeTexture(u32 width, u32 height) {}
+
+void Render::DummyTexture::GenerateMipmaps() {}
+
+void Render::DummyTexture::UpdateSubRegion(u32 x, u32 y, u32 w, u32 h, eDataFormat format, u8 *data) {}
+
+void Render::DummyTexture::Bind() {}
+
+void Render::DummyTexture::Unbind() {}
+
+void Render::DummyTexture::DestroyTexture() {}

--- a/Xenon/Render/Dummy/DummyTexture.cpp
+++ b/Xenon/Render/Dummy/DummyTexture.cpp
@@ -2,18 +2,34 @@
 
 #include "DummyTexture.h"
 
-void Render::DummyTexture::CreateTextureHandle(u32 width, u32 height, s32 flags) {}
+void Render::DummyTexture::CreateTextureHandle(u32 width, u32 height, s32 flags) {
+  LOG_INFO(Render, "DummyTexture::CreateTextureHandle: {}, {}, {}", width, height, flags);
+}
 
-void Render::DummyTexture::CreateTextureWithData(u32 width, u32 height, eDataFormat format, u8* data, u32 dataSize, s32 flags) {}
+void Render::DummyTexture::CreateTextureWithData(u32 width, u32 height, eDataFormat format, u8* data, u32 dataSize, s32 flags) {
+  LOG_INFO(Render, "DummyTexture::CreateTextureWithData: {}, {}, {}, {}, {}", width, height, static_cast<u8>(format), dataSize, flags);
+}
 
-void Render::DummyTexture::ResizeTexture(u32 width, u32 height) {}
+void Render::DummyTexture::ResizeTexture(u32 width, u32 height) {
+  LOG_INFO(Render, "DummyTexture::ResizeTexture: {}, {}", width, height);
+}
 
-void Render::DummyTexture::GenerateMipmaps() {}
+void Render::DummyTexture::GenerateMipmaps() {
+  LOG_INFO(Render, "DummyTexture::GenerateMipmaps");
+}
 
-void Render::DummyTexture::UpdateSubRegion(u32 x, u32 y, u32 w, u32 h, eDataFormat format, u8 *data) {}
+void Render::DummyTexture::UpdateSubRegion(u32 x, u32 y, u32 w, u32 h, eDataFormat format, u8 *data) {
+  LOG_INFO(Render, "DummyTexture::UpdateSubRegion: {}, {}, {}, {}, {}", x, y, w, h, static_cast<u8>(format));
+}
 
-void Render::DummyTexture::Bind() {}
+void Render::DummyTexture::Bind() {
+  LOG_INFO(Render, "DummyTexture::Bind");
+}
 
-void Render::DummyTexture::Unbind() {}
+void Render::DummyTexture::Unbind() {
+  LOG_INFO(Render, "DummyTexture::Unbind");
+}
 
-void Render::DummyTexture::DestroyTexture() {}
+void Render::DummyTexture::DestroyTexture() {
+  LOG_INFO(Render, "DummyTexture::DestroyTexture");
+}

--- a/Xenon/Render/Dummy/DummyTexture.h
+++ b/Xenon/Render/Dummy/DummyTexture.h
@@ -9,14 +9,14 @@ namespace Render {
 
 class DummyTexture : public Texture {
 public:
-    void CreateTextureHandle(u32 width, u32 height, s32 flags) override;
-    void CreateTextureWithData(u32 width, u32 height, eDataFormat format, u8* data, u32 dataSize, s32 flags) override;
-    void ResizeTexture(u32 width, u32 height) override;
-    void GenerateMipmaps() override;
-    void UpdateSubRegion(u32 x, u32 y, u32 w, u32 h, eDataFormat format, u8 *data) override;
-    void Bind() override;
-    void Unbind() override;
-    void DestroyTexture() override;
+  void CreateTextureHandle(u32 width, u32 height, s32 flags) override;
+  void CreateTextureWithData(u32 width, u32 height, eDataFormat format, u8* data, u32 dataSize, s32 flags) override;
+  void ResizeTexture(u32 width, u32 height) override;
+  void GenerateMipmaps() override;
+  void UpdateSubRegion(u32 x, u32 y, u32 w, u32 h, eDataFormat format, u8 *data) override;
+  void Bind() override;
+  void Unbind() override;
+  void DestroyTexture() override;
 };
 
 } // namespace Render

--- a/Xenon/Render/Dummy/DummyTexture.h
+++ b/Xenon/Render/Dummy/DummyTexture.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
-#include "Base/Types.h"
 #include "Render/Abstractions/Texture.h"
+
+#include "Base/Types.h"
+#include "Base/Logging/Log.h"
 
 namespace Render {
 

--- a/Xenon/Render/Dummy/DummyTexture.h
+++ b/Xenon/Render/Dummy/DummyTexture.h
@@ -1,0 +1,22 @@
+// Copyright 2025 Xenon Emulator Project
+
+#pragma once
+
+#include "Base/Types.h"
+#include "Render/Abstractions/Texture.h"
+
+namespace Render {
+
+class DummyTexture : public Texture {
+public:
+    void CreateTextureHandle(u32 width, u32 height, s32 flags) override;
+    void CreateTextureWithData(u32 width, u32 height, eDataFormat format, u8* data, u32 dataSize, s32 flags) override;
+    void ResizeTexture(u32 width, u32 height) override;
+    void GenerateMipmaps() override;
+    void UpdateSubRegion(u32 x, u32 y, u32 w, u32 h, eDataFormat format, u8 *data) override;
+    void Bind() override;
+    void Unbind() override;
+    void DestroyTexture() override;
+};
+
+} // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyResourceFactory.h
+++ b/Xenon/Render/Dummy/Factory/DummyResourceFactory.h
@@ -8,20 +8,26 @@
 #include "Render/Dummy/DummyTexture.h"
 #include "Render/GUI/Dummy.h"
 
+#include "Base/Logging/Log.h"
+
 namespace Render {
 
 class DummyResourceFactory : public ResourceFactory {
 public:
   std::unique_ptr<ShaderFactory> CreateShaderFactory() override {
+    LOG_INFO(Render, "DummyResourceFactory::CreateShaderFactory");
     return std::make_unique<DummyShaderFactory>();
   }
   std::unique_ptr<Buffer> CreateBuffer() override {
+    LOG_INFO(Render, "DummyResourceFactory::CreateBuffer");
     return std::make_unique<DummyBuffer>();
   }
   std::unique_ptr<Texture> CreateTexture() override {
+    LOG_INFO(Render, "DummyResourceFactory::CreateTexture");
     return std::make_unique<DummyTexture>();
   }
   std::unique_ptr<GUI> CreateGUI() override {
+    LOG_INFO(Render, "DummyResourceFactory::CreateGUI");
     return std::make_unique<DummyGUI>();
   }
 };

--- a/Xenon/Render/Dummy/Factory/DummyResourceFactory.h
+++ b/Xenon/Render/Dummy/Factory/DummyResourceFactory.h
@@ -1,0 +1,29 @@
+// Copyright 2025 Xenon Emulator Project
+
+#pragma once
+
+#include "Render/Abstractions/Factory/ResourceFactory.h"
+#include "Render/Dummy/Factory/DummyShaderFactory.h"
+#include "Render/Dummy/DummyBuffer.h"
+#include "Render/Dummy/DummyTexture.h"
+#include "Render/GUI/Dummy.h"
+
+namespace Render {
+
+class DummyResourceFactory : public ResourceFactory {
+public:
+    std::unique_ptr<ShaderFactory> CreateShaderFactory() override {
+        return std::make_unique<DummyShaderFactory>();
+    }
+    std::unique_ptr<Buffer> CreateBuffer() override {
+        return std::make_unique<DummyBuffer>();
+    }
+    std::unique_ptr<Texture> CreateTexture() override {
+        return std::make_unique<DummyTexture>();
+    }
+    std::unique_ptr<GUI> CreateGUI() override {
+        return std::make_unique<DummyGUI>();
+    }
+};
+
+} // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyResourceFactory.h
+++ b/Xenon/Render/Dummy/Factory/DummyResourceFactory.h
@@ -12,18 +12,18 @@ namespace Render {
 
 class DummyResourceFactory : public ResourceFactory {
 public:
-    std::unique_ptr<ShaderFactory> CreateShaderFactory() override {
-        return std::make_unique<DummyShaderFactory>();
-    }
-    std::unique_ptr<Buffer> CreateBuffer() override {
-        return std::make_unique<DummyBuffer>();
-    }
-    std::unique_ptr<Texture> CreateTexture() override {
-        return std::make_unique<DummyTexture>();
-    }
-    std::unique_ptr<GUI> CreateGUI() override {
-        return std::make_unique<DummyGUI>();
-    }
+  std::unique_ptr<ShaderFactory> CreateShaderFactory() override {
+    return std::make_unique<DummyShaderFactory>();
+  }
+  std::unique_ptr<Buffer> CreateBuffer() override {
+    return std::make_unique<DummyBuffer>();
+  }
+  std::unique_ptr<Texture> CreateTexture() override {
+    return std::make_unique<DummyTexture>();
+  }
+  std::unique_ptr<GUI> CreateGUI() override {
+    return std::make_unique<DummyGUI>();
+  }
 };
 
 } // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
+++ b/Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
@@ -7,18 +7,22 @@ namespace Render {
 void DummyShaderFactory::Destroy() {}
 
 std::shared_ptr<Shader> DummyShaderFactory::CreateShader(const std::string &name) {
+  LOG_INFO(Render, "DummyShaderFactory::CreateShader: {}", name);
   return nullptr;
 }
 
 std::shared_ptr<Shader> DummyShaderFactory::GetShader(const std::string &name) {
+  LOG_INFO(Render, "DummyShaderFactory::GetShader: {}", name);
   return nullptr;
 }
 
 std::shared_ptr<Shader> DummyShaderFactory::LoadFromSource(const std::string &name, const std::unordered_map<eShaderType, std::string> &sources) {
+  LOG_INFO(Render, "DummyShaderFactory::LoadFromSource: {}", name);
   return nullptr;
 }
 
 std::shared_ptr<Shader> DummyShaderFactory::LoadFromFile(const std::string &name, const fs::path &path) {
+  LOG_INFO(Render, "DummyShaderFactory::LoadFromFile: {}", name);
   return nullptr;
 }
 

--- a/Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
+++ b/Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
@@ -7,19 +7,19 @@ namespace Render {
 void DummyShaderFactory::Destroy() {}
 
 std::shared_ptr<Shader> DummyShaderFactory::CreateShader(const std::string &name) {
-    return nullptr;
+  return nullptr;
 }
 
 std::shared_ptr<Shader> DummyShaderFactory::GetShader(const std::string &name) {
-    return nullptr;
+  return nullptr;
 }
 
 std::shared_ptr<Shader> DummyShaderFactory::LoadFromSource(const std::string &name, const std::unordered_map<eShaderType, std::string> &sources) {
-    return nullptr;
+  return nullptr;
 }
 
 std::shared_ptr<Shader> DummyShaderFactory::LoadFromFile(const std::string &name, const fs::path &path) {
-    return nullptr;
+  return nullptr;
 }
 
 } // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
+++ b/Xenon/Render/Dummy/Factory/DummyShaderFactory.cpp
@@ -1,0 +1,25 @@
+// Copyright 2025 Xenon Emulator Project
+
+#include "DummyShaderFactory.h"
+
+namespace Render {
+
+void DummyShaderFactory::Destroy() {}
+
+std::shared_ptr<Shader> DummyShaderFactory::CreateShader(const std::string &name) {
+    return nullptr;
+}
+
+std::shared_ptr<Shader> DummyShaderFactory::GetShader(const std::string &name) {
+    return nullptr;
+}
+
+std::shared_ptr<Shader> DummyShaderFactory::LoadFromSource(const std::string &name, const std::unordered_map<eShaderType, std::string> &sources) {
+    return nullptr;
+}
+
+std::shared_ptr<Shader> DummyShaderFactory::LoadFromFile(const std::string &name, const fs::path &path) {
+    return nullptr;
+}
+
+} // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyShaderFactory.h
+++ b/Xenon/Render/Dummy/Factory/DummyShaderFactory.h
@@ -8,11 +8,11 @@ namespace Render {
 
 class DummyShaderFactory : public ShaderFactory {
 public:
-    void Destroy() override;
-    std::shared_ptr<Shader> CreateShader(const std::string &name) override;
-    std::shared_ptr<Shader> LoadFromFile(const std::string &name, const fs::path &path) override;
-    std::shared_ptr<Shader> LoadFromSource(const std::string &name, const std::unordered_map<eShaderType, std::string> &sources) override;
-    std::shared_ptr<Shader> GetShader(const std::string &name) override;
+  void Destroy() override;
+  std::shared_ptr<Shader> CreateShader(const std::string &name) override;
+  std::shared_ptr<Shader> LoadFromFile(const std::string &name, const fs::path &path) override;
+  std::shared_ptr<Shader> LoadFromSource(const std::string &name, const std::unordered_map<eShaderType, std::string> &sources) override;
+  std::shared_ptr<Shader> GetShader(const std::string &name) override;
 };
 
 } // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyShaderFactory.h
+++ b/Xenon/Render/Dummy/Factory/DummyShaderFactory.h
@@ -1,0 +1,18 @@
+// Copyright 2025 Xenon Emulator Project
+
+#pragma once
+
+#include "Render/Abstractions/Factory/ShaderFactory.h"
+
+namespace Render {
+
+class DummyShaderFactory : public ShaderFactory {
+public:
+    void Destroy() override;
+    std::shared_ptr<Shader> CreateShader(const std::string &name) override;
+    std::shared_ptr<Shader> LoadFromFile(const std::string &name, const fs::path &path) override;
+    std::shared_ptr<Shader> LoadFromSource(const std::string &name, const std::unordered_map<eShaderType, std::string> &sources) override;
+    std::shared_ptr<Shader> GetShader(const std::string &name) override;
+};
+
+} // namespace Render

--- a/Xenon/Render/Dummy/Factory/DummyShaderFactory.h
+++ b/Xenon/Render/Dummy/Factory/DummyShaderFactory.h
@@ -4,6 +4,8 @@
 
 #include "Render/Abstractions/Factory/ShaderFactory.h"
 
+#include "Base/Logging/Log.h"
+
 namespace Render {
 
 class DummyShaderFactory : public ShaderFactory {

--- a/Xenon/Render/DummyRenderer.cpp
+++ b/Xenon/Render/DummyRenderer.cpp
@@ -7,38 +7,58 @@
 namespace Render {
 DummyRenderer::DummyRenderer(RAM *ram, SDL_Window *mainWindow) :
   Renderer(ram, mainWindow) {
-  LOG_WARNING(Render, "Using dummy renderer!");
+  LOG_WARNING(Render, "DummyRenderer::DummyRenderer: Using dummy renderer!");
 }
 
 DummyRenderer::~DummyRenderer() {
+  LOG_INFO(Render, "DummyRenderer::~DummyRenderer");
   Shutdown();
 }
 
 void DummyRenderer::BackendStart() {
+  LOG_INFO(Render, "DummyRenderer::BackendStart");
   resourceFactory = std::make_unique<DummyResourceFactory>();
 }
 
-void DummyRenderer::BackendSDLProperties(SDL_PropertiesID properties) {}
+void DummyRenderer::BackendSDLProperties(SDL_PropertiesID properties) {
+  LOG_INFO(Render, "DummyRenderer::BackendSDLProperties");
+}
 
-void DummyRenderer::BackendSDLInit() {}
+void DummyRenderer::BackendSDLInit() {
+  LOG_INFO(Render, "DummyRenderer::BackendSDLInit");
+}
 
-void DummyRenderer::BackendShutdown() {}
+void DummyRenderer::BackendShutdown() {
+  LOG_INFO(Render, "DummyRenderer::BackendShutdown");
+}
 
-void DummyRenderer::BackendSDLShutdown() {}
+void DummyRenderer::BackendSDLShutdown() {
+  LOG_INFO(Render, "DummyRenderer::BackendSDLShutdown");
+}
 
-void DummyRenderer::BackendResize(s32 x, s32 y) {}
+void DummyRenderer::BackendResize(s32 x, s32 y) {
+  LOG_INFO(Render, "DummyRenderer::BackendResize: {}, {}", x, y);
+}
 
-void DummyRenderer::OnCompute() {}
+void DummyRenderer::OnCompute() {
+  LOG_INFO(Render, "DummyRenderer::OnCompute");
+}
 
-void DummyRenderer::OnBind() {}
+void DummyRenderer::OnBind() {
+  LOG_INFO(Render, "DummyRenderer::OnBind");
+}
 
-void DummyRenderer::OnSwap(SDL_Window* window) {}
+void DummyRenderer::OnSwap(SDL_Window* window) {
+  LOG_INFO(Render, "DummyRenderer::OnSwap");
+}
 
 s32 DummyRenderer::GetBackbufferFlags() {
+  LOG_INFO(Render, "DummyRenderer::GetBackbufferFlags");
   return 0;
 }
 
 void* DummyRenderer::GetBackendContext() {
+  LOG_INFO(Render, "DummyRenderer::GetBackendContext");
   return nullptr;
 }
 

--- a/Xenon/Render/DummyRenderer.cpp
+++ b/Xenon/Render/DummyRenderer.cpp
@@ -6,16 +6,16 @@
 
 namespace Render {
 DummyRenderer::DummyRenderer(RAM *ram, SDL_Window *mainWindow) :
-    Renderer(ram, mainWindow) {
-    LOG_WARNING(Render, "Using dummy renderer!");
+  Renderer(ram, mainWindow) {
+  LOG_WARNING(Render, "Using dummy renderer!");
 }
 
 DummyRenderer::~DummyRenderer() {
-    Shutdown();
+  Shutdown();
 }
 
 void DummyRenderer::BackendStart() {
-    resourceFactory = std::make_unique<DummyResourceFactory>();
+  resourceFactory = std::make_unique<DummyResourceFactory>();
 }
 
 void DummyRenderer::BackendSDLProperties(SDL_PropertiesID properties) {}
@@ -35,11 +35,11 @@ void DummyRenderer::OnBind() {}
 void DummyRenderer::OnSwap(SDL_Window* window) {}
 
 s32 DummyRenderer::GetBackbufferFlags() {
-    return 0;
+  return 0;
 }
 
 void* DummyRenderer::GetBackendContext() {
-    return nullptr;
+  return nullptr;
 }
 
 } // namespace Render

--- a/Xenon/Render/DummyRenderer.cpp
+++ b/Xenon/Render/DummyRenderer.cpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Xenon Emulator Project
+
+#include "DummyRenderer.h"
+
+#include "Dummy/Factory/DummyResourceFactory.h"
+
+namespace Render {
+DummyRenderer::DummyRenderer(RAM *ram, SDL_Window *mainWindow) :
+    Renderer(ram, mainWindow) {
+    LOG_WARNING(Render, "Using dummy renderer!");
+}
+
+DummyRenderer::~DummyRenderer() {
+    Shutdown();
+}
+
+void DummyRenderer::BackendStart() {
+    resourceFactory = std::make_unique<DummyResourceFactory>();
+}
+
+void DummyRenderer::BackendSDLProperties(SDL_PropertiesID properties) {}
+
+void DummyRenderer::BackendSDLInit() {}
+
+void DummyRenderer::BackendShutdown() {}
+
+void DummyRenderer::BackendSDLShutdown() {}
+
+void DummyRenderer::BackendResize(s32 x, s32 y) {}
+
+void DummyRenderer::OnCompute() {}
+
+void DummyRenderer::OnBind() {}
+
+void DummyRenderer::OnSwap(SDL_Window* window) {}
+
+s32 DummyRenderer::GetBackbufferFlags() {
+    return 0;
+}
+
+void* DummyRenderer::GetBackendContext() {
+    return nullptr;
+}
+
+} // namespace Render

--- a/Xenon/Render/DummyRenderer.h
+++ b/Xenon/Render/DummyRenderer.h
@@ -4,6 +4,8 @@
 
 #include "Abstractions/Renderer.h"
 
+#include "Base/Logging/Log.h"
+
 namespace Render {
 
 class DummyRenderer : public Renderer {

--- a/Xenon/Render/DummyRenderer.h
+++ b/Xenon/Render/DummyRenderer.h
@@ -8,19 +8,19 @@ namespace Render {
 
 class DummyRenderer : public Renderer {
 public:
-    DummyRenderer(RAM *ram, SDL_Window *mainWindow);
-    ~DummyRenderer();
-    void BackendSDLProperties(SDL_PropertiesID properties) override;
-    void BackendStart() override;
-    void BackendShutdown() override;
-    void BackendSDLInit() override;
-    void BackendSDLShutdown() override;
-    void BackendResize(s32 x, s32 y) override;
-    void OnCompute() override;
-    void OnBind() override;
-    void OnSwap(SDL_Window* window) override;
-    s32 GetBackbufferFlags() override;
-    void* GetBackendContext() override;
+  DummyRenderer(RAM *ram, SDL_Window *mainWindow);
+  ~DummyRenderer();
+  void BackendSDLProperties(SDL_PropertiesID properties) override;
+  void BackendStart() override;
+  void BackendShutdown() override;
+  void BackendSDLInit() override;
+  void BackendSDLShutdown() override;
+  void BackendResize(s32 x, s32 y) override;
+  void OnCompute() override;
+  void OnBind() override;
+  void OnSwap(SDL_Window* window) override;
+  s32 GetBackbufferFlags() override;
+  void* GetBackendContext() override;
 };
 
 } // namespace Render

--- a/Xenon/Render/DummyRenderer.h
+++ b/Xenon/Render/DummyRenderer.h
@@ -1,0 +1,26 @@
+// Copyright 2025 Xenon Emulator Project
+
+#pragma once
+
+#include "Abstractions/Renderer.h"
+
+namespace Render {
+
+class DummyRenderer : public Renderer {
+public:
+    DummyRenderer(RAM *ram, SDL_Window *mainWindow);
+    ~DummyRenderer();
+    void BackendSDLProperties(SDL_PropertiesID properties) override;
+    void BackendStart() override;
+    void BackendShutdown() override;
+    void BackendSDLInit() override;
+    void BackendSDLShutdown() override;
+    void BackendResize(s32 x, s32 y) override;
+    void OnCompute() override;
+    void OnBind() override;
+    void OnSwap(SDL_Window* window) override;
+    s32 GetBackbufferFlags() override;
+    void* GetBackendContext() override;
+};
+
+} // namespace Render

--- a/Xenon/Render/GUI/Dummy.cpp
+++ b/Xenon/Render/GUI/Dummy.cpp
@@ -2,10 +2,18 @@
 
 #include "Dummy.h"
 
-void Render::DummyGUI::InitBackend(void *context) {}
+void Render::DummyGUI::InitBackend(void *context) {
+  LOG_INFO(Render, "DummyGUI::InitBackend");
+}
 
-void Render::DummyGUI::ShutdownBackend() {}
+void Render::DummyGUI::ShutdownBackend() {
+  LOG_INFO(Render, "DummyGUI::ShutdownBackend");
+}
 
-void Render::DummyGUI::BeginSwap() {}
+void Render::DummyGUI::BeginSwap() {
+  LOG_INFO(Render, "DummyGUI::BeginSwap");
+}
 
-void Render::DummyGUI::EndSwap() {}
+void Render::DummyGUI::EndSwap() {
+  LOG_INFO(Render, "DummyGUI::EndSwap");
+}

--- a/Xenon/Render/GUI/Dummy.cpp
+++ b/Xenon/Render/GUI/Dummy.cpp
@@ -1,0 +1,11 @@
+// Copyright 2025 Xenon Emulator Project
+
+#include "Dummy.h"
+
+void Render::DummyGUI::InitBackend(void *context) {}
+
+void Render::DummyGUI::ShutdownBackend() {}
+
+void Render::DummyGUI::BeginSwap() {}
+
+void Render::DummyGUI::EndSwap() {}

--- a/Xenon/Render/GUI/Dummy.h
+++ b/Xenon/Render/GUI/Dummy.h
@@ -1,0 +1,17 @@
+// Copyright 2025 Xenon Emulator Project
+
+#pragma once
+
+#include "Render/GUI/GUI.h"
+
+namespace Render {
+
+class DummyGUI : public GUI {
+public:
+  void InitBackend(void *context) override;
+  void ShutdownBackend() override;
+  void BeginSwap() override;
+  void EndSwap() override;
+};
+
+} // namespace Render

--- a/Xenon/Render/GUI/Dummy.h
+++ b/Xenon/Render/GUI/Dummy.h
@@ -4,6 +4,8 @@
 
 #include "Render/GUI/GUI.h"
 
+#include "Base/Logging/Log.h"
+
 namespace Render {
 
 class DummyGUI : public GUI {


### PR DESCRIPTION
Provides a sort of middle ground between true headless and a proper renderer. Allows for testing of window creation, audio, etc, without the added baggage of GPU work.

TODO:
- [ ] Provide a config option for backend