### PR TITLE
ARM64 macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,10 +146,6 @@ jobs:
         run: |
           brew install ninja llvm
 
-      - name: Use Homebrew clang
-        run: |
-          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-
       - name: Cache CMake Configuration
         uses: actions/cache@main
         env:
@@ -170,7 +166,7 @@ jobs:
           key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
       - name: Configure CMake
-        run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
   macOS:
     name: macOS (ARM)
     runs-on: macos-latest
+    needs: get-info
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,11 @@ jobs:
 
       - name: Install Dependencies (macOS)
         run: |
-          brew install ninja
+          brew install ninja llvm
+
+      - name: Use Homebrew clang
+        run: |
+          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 
       - name: Cache CMake Configuration
         uses: actions/cache@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@main
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Setup latest Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,3 +126,50 @@ jobs:
       - uses: cachix/install-nix-action@master
       - name: Build Xenon
         run: nix build .#xenon -L
+
+  macOS:
+    name: macOS (ARM)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+
+      - name: Setup latest Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install Dependencies (macOS)
+        run: |
+          brew install ninja
+
+      - name: Cache CMake Configuration
+        uses: actions/cache@main
+        env:
+          cache-name: ${{ runner.os }}-xenon-cache-config
+        with:
+          path: |
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+      - name: Cache CMake Build
+        uses: hendrikmuhs/ccache-action@v1.2.18
+        env:
+          cache-name: ${{ runner.os }}-xenon-cache-build
+        with:
+          append-timestamp: false
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
+      - name: Configure CMake
+        run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER_ID=Clang -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)
+
+      - name: Upload macOS Artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: Xenon-macos64-${{ needs.get-info.outputs.commit }}-${{ needs.get-info.outputs.shorthash }}
+          path: ${{github.workspace}}/build/Xenon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
           key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
       - name: Configure CMake
-        run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER_ID=Clang -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)

--- a/Deps/Docs/Building/building-macos.md
+++ b/Deps/Docs/Building/building-macos.md
@@ -1,0 +1,18 @@
+# Building Xenon for macOS
+
+## Dependencies
+
+Make sure you have the most recent version of Xcode or Xcode CLT installed.
+
+Xenon needs to be built on llvm clang **not** AppleClang.  
+
+```bash
+brew install ninja cmake llvm
+```
+
+## Building
+
+```bash
+cmake -G Ninja -B build -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++
+cmake --build build
+```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ We need talented developers more than ever to contribute to the project and move
 # Building
 - [**Windows**](https://github.com/xenon-emu/Xenon/blob/main/Deps/Docs/Building/building-windows.md)
 - [**Linux**](https://github.com/xenon-emu/Xenon/blob/main/Deps/Docs/Building/building-linux.md)
+- [**macOS**](https://github.com/xenon-emu/Xenon/blob/main/Deps/Docs/Building/building-macos.md)
 
 # License
 - [**GPL-2.0 license**](https://github.com/xenon-emu/Xenon/blob/main/LICENSE)


### PR DESCRIPTION
For now, we need to use Homebrew llvm clang because AppleClang lacks `std::jthread`