### PR TITLE
[SFCX] Fixup segfault when no valid nand.bin is present

### DIFF
--- a/Xenon/Core/RootBus/HostBridge/PCIBridge/SFCX/SFCX.cpp
+++ b/Xenon/Core/RootBus/HostBridge/PCIBridge/SFCX/SFCX.cpp
@@ -75,12 +75,14 @@ Xe::PCIDev::SFCX::SFCX(const std::string &deviceName, u64 size, const std::strin
   if (!nandFile.is_open()) {
     LOG_CRITICAL(SFCX, "Fatal error! Please make sure your NAND (or NAND path) is valid!");
     Base::SystemPause();
+    return;
   }
 
   // Check file magic
   if (!checkMagic()) {
     LOG_CRITICAL(SFCX, "Fatal error! The loaded 'nand.bin' doesn't correspond to a Xbox 360 NAND.");
     Base::SystemPause();
+    return;
   }
 
   // Read NAND Image data


### PR DESCRIPTION
Before this change, if no valid NAND was specified, the SFCX thread would continue to run and would result in undefined behaviour. On a Debian system, this caused a segfault. With this commit applied, there is no more segfault and (empty-flash) execution can continue.

Personally, I'd totally exit the emulator at this point. However, I tried to keep inline with the behaviour that an exception would cause.