### PR TITLE
Fix Parsing RAM Size

### DIFF
--- a/Xenon/Core/RAM/RAM.cpp
+++ b/Xenon/Core/RAM/RAM.cpp
@@ -20,7 +20,7 @@ RAM::RAM(const std::string &deviceName, u64 startAddress, std::string size, bool
   } else {
     u64 charPos = size.find_first_of(firstChar);
     if (charPos != -1) {
-      std::string number = size.substr(0, size.length() - charPos);
+      std::string number = size.substr(0, charPos);
       std::string unit = size.substr(charPos);
       f64 ramSizeF = std::stod(number.c_str());
       f64 unitF = 0;


### PR DESCRIPTION
Fix when trying to set RAMSize as 1024MiB the value of `number` is incorrectly parsed as `102` instead of `1024`.